### PR TITLE
feat: add --ip and --port CLI flags

### DIFF
--- a/cmd/figma-mcp-go/main.go
+++ b/cmd/figma-mcp-go/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -20,9 +21,17 @@ var version = "dev"
 var logger = log.New(os.Stderr, "", 0)
 
 func main() {
-	ip := flag.String("ip", "127.0.0.1", "IP address to listen on")
+	ip := flag.String("ip", "127.0.0.1", "IP address to listen on (use 0.0.0.0 to accept remote connections)")
 	port := flag.Int("port", 1994, "port to listen on")
 	flag.Parse()
+
+	parsedIP := net.ParseIP(*ip)
+	if parsedIP == nil {
+		logger.Fatalf("invalid IP address: %q", *ip)
+	}
+	if !parsedIP.IsLoopback() {
+		logger.Printf("WARNING: binding to %s — server will be reachable from the network with no authentication", *ip)
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/cmd/figma-mcp-go/main.go
+++ b/cmd/figma-mcp-go/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"os"
 	"os/signal"
@@ -18,14 +19,16 @@ var version = "dev"
 
 var logger = log.New(os.Stderr, "", 0)
 
-const port = 1994
-
 func main() {
+	ip := flag.String("ip", "127.0.0.1", "IP address to listen on")
+	port := flag.Int("port", 1994, "port to listen on")
+	flag.Parse()
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	node := internal.NewNode(port, version)
-	election := internal.NewElection(port, node)
+	node := internal.NewNode(*ip, *port, version)
+	election := internal.NewElection(*ip, *port, node)
 
 	if err := election.Start(ctx); err != nil {
 		logger.Fatalf("election start: %v", err)

--- a/internal/bridge.go
+++ b/internal/bridge.go
@@ -47,7 +47,7 @@ func NewBridge() *Bridge {
 // replaces the old one (same behaviour as the TypeScript version).
 func (b *Bridge) HandleUpgrade(w http.ResponseWriter, r *http.Request) {
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true, // plugin connects from localhost
+		InsecureSkipVerify: true, // skip Origin check — plugin connects via Figma's sandbox
 	})
 	if err != nil {
 		bridgeLogger.Printf("upgrade error: %v", err)

--- a/internal/election.go
+++ b/internal/election.go
@@ -20,12 +20,12 @@ type Election struct {
 	cancel   context.CancelFunc
 }
 
-// NewElection creates an Election for the given port and node.
-func NewElection(port int, node *Node) *Election {
+// NewElection creates an Election for the given ip, port, and node.
+func NewElection(ip string, port int, node *Node) *Election {
 	return &Election{
 		port:     port,
 		node:     node,
-		follower: NewFollower("http://localhost:" + itoa(port)),
+		follower: NewFollower("http://" + ip + ":" + itoa(port)),
 	}
 }
 

--- a/internal/election_test.go
+++ b/internal/election_test.go
@@ -39,14 +39,14 @@ func TestItoa(t *testing.T) {
 
 func TestElectionTick_LeaderDoesNothing(t *testing.T) {
 	port := freePort(t)
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 
 	if err := n.BecomeLeader(); err != nil {
 		t.Fatalf("BecomeLeader: %v", err)
 	}
 	t.Cleanup(n.Stop)
 
-	e := NewElection(port, n)
+	e := NewElection("127.0.0.1", port,n)
 	if err := e.tick(context.Background()); err != nil {
 		t.Errorf("tick for LEADER: %v", err)
 	}
@@ -72,10 +72,10 @@ func TestElectionTick_FollowerHealthyLeader(t *testing.T) {
 	}
 	testPort := tcpAddr.Port
 
-	n := NewNode(testPort, "test")
+	n := NewNode("127.0.0.1", testPort, "test")
 	n.BecomeFollower()
 
-	e := NewElection(testPort, n)
+	e := NewElection("127.0.0.1", testPort, n)
 	if err := e.tick(context.Background()); err != nil {
 		t.Errorf("tick: %v", err)
 	}
@@ -90,11 +90,11 @@ func TestElectionTick_FollowerHealthyLeader(t *testing.T) {
 func TestElectionTick_FollowerDeadLeader_TakesOver(t *testing.T) {
 	port := freePort(t)
 
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 	n.BecomeFollower()
 	t.Cleanup(n.Stop)
 
-	e := NewElection(port, n)
+	e := NewElection("127.0.0.1", port,n)
 	if err := e.tick(context.Background()); err != nil {
 		t.Errorf("tick: %v", err)
 	}
@@ -109,11 +109,11 @@ func TestElectionTick_FollowerDeadLeader_TakesOver(t *testing.T) {
 
 func TestElectionTick_UnknownBecomesLeader(t *testing.T) {
 	port := freePort(t)
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 	// Role stays UNKNOWN — no BecomeLeader/BecomeFollower called.
 	t.Cleanup(n.Stop)
 
-	e := NewElection(port, n)
+	e := NewElection("127.0.0.1", port,n)
 	if err := e.tick(context.Background()); err != nil {
 		t.Errorf("tick: %v", err)
 	}
@@ -127,10 +127,10 @@ func TestElectionTick_UnknownBecomesLeader(t *testing.T) {
 
 func TestElectionStart_Stop(t *testing.T) {
 	port := freePort(t)
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 	t.Cleanup(n.Stop)
 
-	e := NewElection(port, n)
+	e := NewElection("127.0.0.1", port,n)
 	ctx := context.Background()
 
 	if err := e.Start(ctx); err != nil {
@@ -154,13 +154,13 @@ func TestElectionStart_Stop(t *testing.T) {
 func TestElection_ConcurrentStart_OneLeader(t *testing.T) {
 	port := freePort(t)
 
-	n1 := NewNode(port, "test")
-	n2 := NewNode(port, "test")
+	n1 := NewNode("127.0.0.1", port, "test")
+	n2 := NewNode("127.0.0.1", port, "test")
 	t.Cleanup(n1.Stop)
 	t.Cleanup(n2.Stop)
 
-	e1 := NewElection(port, n1)
-	e2 := NewElection(port, n2)
+	e1 := NewElection("127.0.0.1", port,n1)
+	e2 := NewElection("127.0.0.1", port,n2)
 	t.Cleanup(e1.Stop)
 	t.Cleanup(e2.Stop)
 
@@ -198,7 +198,7 @@ func TestElection_ConcurrentTakeover_OneLeader(t *testing.T) {
 	port := freePort(t)
 
 	// Elect a real leader so followers can ping it.
-	leader := NewNode(port, "test")
+	leader := NewNode("127.0.0.1", port, "test")
 	if err := leader.BecomeLeader(); err != nil {
 		t.Fatalf("BecomeLeader: %v", err)
 	}
@@ -207,9 +207,9 @@ func TestElection_ConcurrentTakeover_OneLeader(t *testing.T) {
 	nodes := make([]*Node, n)
 	elections := make([]*Election, n)
 	for i := range nodes {
-		nodes[i] = NewNode(port, "test")
+		nodes[i] = NewNode("127.0.0.1", port, "test")
 		nodes[i].BecomeFollower()
-		elections[i] = NewElection(port, nodes[i])
+		elections[i] = NewElection("127.0.0.1", port,nodes[i])
 		t.Cleanup(nodes[i].Stop)
 	}
 

--- a/internal/election_test.go
+++ b/internal/election_test.go
@@ -46,7 +46,7 @@ func TestElectionTick_LeaderDoesNothing(t *testing.T) {
 	}
 	t.Cleanup(n.Stop)
 
-	e := NewElection("127.0.0.1", port,n)
+	e := NewElection("127.0.0.1", port, n)
 	if err := e.tick(context.Background()); err != nil {
 		t.Errorf("tick for LEADER: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestElectionTick_FollowerDeadLeader_TakesOver(t *testing.T) {
 	n.BecomeFollower()
 	t.Cleanup(n.Stop)
 
-	e := NewElection("127.0.0.1", port,n)
+	e := NewElection("127.0.0.1", port, n)
 	if err := e.tick(context.Background()); err != nil {
 		t.Errorf("tick: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestElectionTick_UnknownBecomesLeader(t *testing.T) {
 	// Role stays UNKNOWN — no BecomeLeader/BecomeFollower called.
 	t.Cleanup(n.Stop)
 
-	e := NewElection("127.0.0.1", port,n)
+	e := NewElection("127.0.0.1", port, n)
 	if err := e.tick(context.Background()); err != nil {
 		t.Errorf("tick: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestElectionStart_Stop(t *testing.T) {
 	n := NewNode("127.0.0.1", port, "test")
 	t.Cleanup(n.Stop)
 
-	e := NewElection("127.0.0.1", port,n)
+	e := NewElection("127.0.0.1", port, n)
 	ctx := context.Background()
 
 	if err := e.Start(ctx); err != nil {
@@ -159,8 +159,8 @@ func TestElection_ConcurrentStart_OneLeader(t *testing.T) {
 	t.Cleanup(n1.Stop)
 	t.Cleanup(n2.Stop)
 
-	e1 := NewElection("127.0.0.1", port,n1)
-	e2 := NewElection("127.0.0.1", port,n2)
+	e1 := NewElection("127.0.0.1", port, n1)
+	e2 := NewElection("127.0.0.1", port, n2)
 	t.Cleanup(e1.Stop)
 	t.Cleanup(e2.Stop)
 
@@ -209,7 +209,7 @@ func TestElection_ConcurrentTakeover_OneLeader(t *testing.T) {
 	for i := range nodes {
 		nodes[i] = NewNode("127.0.0.1", port, "test")
 		nodes[i].BecomeFollower()
-		elections[i] = NewElection("127.0.0.1", port,nodes[i])
+		elections[i] = NewElection("127.0.0.1", port, nodes[i])
 		t.Cleanup(nodes[i].Stop)
 	}
 

--- a/internal/follower_test.go
+++ b/internal/follower_test.go
@@ -28,7 +28,7 @@ func TestFollowerPing_Success(t *testing.T) {
 
 func TestFollowerPing_ServerDown(t *testing.T) {
 	// Use a port that nothing is listening on.
-	f := NewFollower("http://localhost:1")
+	f := NewFollower("http://127.0.0.1:1")
 	if f.Ping(context.Background()) {
 		t.Error("expected Ping to return false when server is unreachable")
 	}
@@ -113,7 +113,7 @@ func TestFollowerSend_InvalidJSON(t *testing.T) {
 }
 
 func TestFollowerSend_ServerDown(t *testing.T) {
-	f := NewFollower("http://localhost:1")
+	f := NewFollower("http://127.0.0.1:1")
 	_, err := f.Send(context.Background(), "get_node", []string{"1:1"}, nil)
 	if err == nil {
 		t.Error("expected error when server is unreachable")

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// freePort finds an available TCP port on localhost.
+// freePort finds an available TCP port on 127.0.0.1.
 func freePort(t *testing.T) int {
 	t.Helper()
 	ln, err := net.Listen("tcp", ":0")

--- a/internal/leader.go
+++ b/internal/leader.go
@@ -23,15 +23,17 @@ var leaderLogger = log.New(os.Stderr, "[leader] ", 0)
 //	/ping — Health check (GET)
 //	/rpc  — JSON RPC for follower tool calls (POST)
 type Leader struct {
+	ip      string
 	port    int
 	bridge  *Bridge
 	server  *http.Server
 	version string
 }
 
-// NewLeader creates a Leader. Call Start() to bind the port.
-func NewLeader(port int, version string) *Leader {
+// NewLeader creates a Leader. Call Start() to bind the ip:port.
+func NewLeader(ip string, port int, version string) *Leader {
 	return &Leader{
+		ip:      ip,
 		port:    port,
 		bridge:  NewBridge(),
 		version: version,
@@ -46,7 +48,7 @@ func (l *Leader) GetBridge() *Bridge {
 // Start binds the port and begins serving. Returns an error immediately
 // if the port is already in use (EADDRINUSE → caller detects another leader).
 func (l *Leader) Start() error {
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", l.port))
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", l.ip, l.port))
 	if err != nil {
 		return err // includes EADDRINUSE
 	}
@@ -65,7 +67,7 @@ func (l *Leader) Start() error {
 		}
 	}()
 
-	leaderLogger.Printf("listening on :%d", l.port)
+	leaderLogger.Printf("listening on %s:%d", l.ip, l.port)
 	return nil
 }
 

--- a/internal/leader_test.go
+++ b/internal/leader_test.go
@@ -177,7 +177,7 @@ func TestLeaderPingEndpoint(t *testing.T) {
 	}
 	t.Cleanup(l.Stop)
 
-	f := NewFollower("http://localhost:" + itoa(port))
+	f := NewFollower("http://127.0.0.1:" + itoa(port))
 	if !f.Ping(t.Context()) {
 		t.Error("expected ping to succeed for running leader")
 	}

--- a/internal/leader_test.go
+++ b/internal/leader_test.go
@@ -12,7 +12,7 @@ import (
 // ── handlePing ────────────────────────────────────────────────────────────────
 
 func TestLeaderHandlePing_OK(t *testing.T) {
-	l := NewLeader(0, "v1.2.3")
+	l := NewLeader("127.0.0.1", 0, "v1.2.3")
 
 	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
 	w := httptest.NewRecorder()
@@ -35,7 +35,7 @@ func TestLeaderHandlePing_OK(t *testing.T) {
 }
 
 func TestLeaderHandlePing_MethodNotAllowed(t *testing.T) {
-	l := NewLeader(0, "")
+	l := NewLeader("127.0.0.1", 0, "")
 
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
 		req := httptest.NewRequest(method, "/ping", nil)
@@ -51,7 +51,7 @@ func TestLeaderHandlePing_MethodNotAllowed(t *testing.T) {
 // ── handleRPC ─────────────────────────────────────────────────────────────────
 
 func TestLeaderHandleRPC_MethodNotAllowed(t *testing.T) {
-	l := NewLeader(0, "")
+	l := NewLeader("127.0.0.1", 0, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/rpc", nil)
 	w := httptest.NewRecorder()
@@ -63,7 +63,7 @@ func TestLeaderHandleRPC_MethodNotAllowed(t *testing.T) {
 }
 
 func TestLeaderHandleRPC_InvalidJSON(t *testing.T) {
-	l := NewLeader(0, "")
+	l := NewLeader("127.0.0.1", 0, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/rpc", bytes.NewBufferString("{bad json}"))
 	w := httptest.NewRecorder()
@@ -80,7 +80,7 @@ func TestLeaderHandleRPC_InvalidJSON(t *testing.T) {
 }
 
 func TestLeaderHandleRPC_ValidationError(t *testing.T) {
-	l := NewLeader(0, "")
+	l := NewLeader("127.0.0.1", 0, "")
 
 	// set_text with nodeId but missing text → validation error
 	body, _ := json.Marshal(RPCRequest{
@@ -103,7 +103,7 @@ func TestLeaderHandleRPC_ValidationError(t *testing.T) {
 }
 
 func TestLeaderHandleRPC_BridgeNotConnected(t *testing.T) {
-	l := NewLeader(0, "")
+	l := NewLeader("127.0.0.1", 0, "")
 
 	// get_document has no required params — passes validation, hits bridge
 	body, _ := json.Marshal(RPCRequest{Tool: "get_document"})
@@ -126,7 +126,7 @@ func TestLeaderHandleRPC_BridgeNotConnected(t *testing.T) {
 
 func TestLeaderStart_BindsPort(t *testing.T) {
 	port := freePort(t)
-	l := NewLeader(port, "")
+	l := NewLeader("127.0.0.1", port, "")
 
 	if err := l.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -134,7 +134,7 @@ func TestLeaderStart_BindsPort(t *testing.T) {
 	t.Cleanup(l.Stop)
 
 	// Second leader on the same port must fail.
-	l2 := NewLeader(port, "")
+	l2 := NewLeader("127.0.0.1", port, "")
 	if err := l2.Start(); err == nil {
 		l2.Stop()
 		t.Error("expected error when binding already-used port")
@@ -143,7 +143,7 @@ func TestLeaderStart_BindsPort(t *testing.T) {
 
 func TestLeaderStop_FreesPort(t *testing.T) {
 	port := freePort(t)
-	l := NewLeader(port, "")
+	l := NewLeader("127.0.0.1", port, "")
 
 	if err := l.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -153,7 +153,7 @@ func TestLeaderStop_FreesPort(t *testing.T) {
 	// Allow OS to release the port.
 	time.Sleep(20 * time.Millisecond)
 
-	l2 := NewLeader(port, "")
+	l2 := NewLeader("127.0.0.1", port, "")
 	if err := l2.Start(); err != nil {
 		t.Fatalf("port should be free after Stop: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestLeaderStop_FreesPort(t *testing.T) {
 }
 
 func TestLeaderStop_Idempotent(t *testing.T) {
-	l := NewLeader(0, "")
+	l := NewLeader("127.0.0.1", 0, "")
 	// Stop on a never-started leader should not panic.
 	l.Stop()
 	l.Stop()
@@ -171,7 +171,7 @@ func TestLeaderStop_Idempotent(t *testing.T) {
 
 func TestLeaderPingEndpoint(t *testing.T) {
 	port := freePort(t)
-	l := NewLeader(port, "test-ver")
+	l := NewLeader("127.0.0.1", port, "test-ver")
 	if err := l.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/node.go
+++ b/internal/node.go
@@ -15,6 +15,7 @@ var nodeLogger = log.New(os.Stderr, "[node] ", 0)
 type Node struct {
 	mu       sync.RWMutex
 	role     Role
+	ip       string
 	port     int
 	leader   *Leader
 	follower *Follower
@@ -22,12 +23,13 @@ type Node struct {
 }
 
 // NewNode creates a Node in the Unknown role.
-func NewNode(port int, version string) *Node {
+func NewNode(ip string, port int, version string) *Node {
 	return &Node{
+		ip:       ip,
 		port:     port,
 		role:     RoleUnknown,
 		version:  version,
-		follower: NewFollower(fmt.Sprintf("http://localhost:%d", port)),
+		follower: NewFollower(fmt.Sprintf("http://%s:%d", ip, port)),
 	}
 }
 
@@ -86,7 +88,7 @@ func (n *Node) BecomeLeader() error {
 		return nil
 	}
 
-	leader := NewLeader(n.port, n.version)
+	leader := NewLeader(n.ip, n.port, n.version)
 	if err := leader.Start(); err != nil {
 		return err
 	}

--- a/internal/node_test.go
+++ b/internal/node_test.go
@@ -31,7 +31,7 @@ func TestNodeRoleName(t *testing.T) {
 // ── NewNode ───────────────────────────────────────────────────────────────────
 
 func TestNewNode_StartsUnknown(t *testing.T) {
-	n := NewNode(19940, "test")
+	n := NewNode("127.0.0.1", 19940, "test")
 	if n.Role() != RoleUnknown {
 		t.Errorf("new node role = %v, want UNKNOWN", n.Role())
 	}
@@ -41,7 +41,7 @@ func TestNewNode_StartsUnknown(t *testing.T) {
 
 func TestNodeBecomeLeader(t *testing.T) {
 	port := freePort(t)
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 	t.Cleanup(n.Stop)
 
 	if err := n.BecomeLeader(); err != nil {
@@ -55,13 +55,13 @@ func TestNodeBecomeLeader(t *testing.T) {
 func TestNodeBecomeLeader_PortTaken(t *testing.T) {
 	port := freePort(t)
 
-	n1 := NewNode(port, "test")
+	n1 := NewNode("127.0.0.1", port, "test")
 	if err := n1.BecomeLeader(); err != nil {
 		t.Fatalf("first BecomeLeader: %v", err)
 	}
 	t.Cleanup(n1.Stop)
 
-	n2 := NewNode(port, "test")
+	n2 := NewNode("127.0.0.1", port, "test")
 	if err := n2.BecomeLeader(); err == nil {
 		n2.Stop()
 		t.Error("expected error when port is already taken")
@@ -70,7 +70,7 @@ func TestNodeBecomeLeader_PortTaken(t *testing.T) {
 
 func TestNodeBecomeLeader_Idempotent(t *testing.T) {
 	port := freePort(t)
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 	t.Cleanup(n.Stop)
 
 	if err := n.BecomeLeader(); err != nil {
@@ -85,7 +85,7 @@ func TestNodeBecomeLeader_Idempotent(t *testing.T) {
 // ── BecomeFollower ────────────────────────────────────────────────────────────
 
 func TestNodeBecomeFollower(t *testing.T) {
-	n := NewNode(19940, "test")
+	n := NewNode("127.0.0.1", 19940, "test")
 	n.BecomeFollower()
 	if n.Role() != RoleFollower {
 		t.Errorf("role = %v, want FOLLOWER", n.Role())
@@ -93,7 +93,7 @@ func TestNodeBecomeFollower(t *testing.T) {
 }
 
 func TestNodeBecomeFollower_Idempotent(t *testing.T) {
-	n := NewNode(19940, "test")
+	n := NewNode("127.0.0.1", 19940, "test")
 	n.BecomeFollower()
 	n.BecomeFollower() // should not panic
 	if n.Role() != RoleFollower {
@@ -103,7 +103,7 @@ func TestNodeBecomeFollower_Idempotent(t *testing.T) {
 
 func TestNodeBecomeFollower_FromLeader(t *testing.T) {
 	port := freePort(t)
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 
 	if err := n.BecomeLeader(); err != nil {
 		t.Fatalf("BecomeLeader: %v", err)
@@ -117,7 +117,7 @@ func TestNodeBecomeFollower_FromLeader(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// Port should be free now — a new leader can bind it.
-	n2 := NewNode(port, "test")
+	n2 := NewNode("127.0.0.1", port, "test")
 	if err := n2.BecomeLeader(); err != nil {
 		t.Fatalf("new node could not bind freed port: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestNodeBecomeFollower_FromLeader(t *testing.T) {
 
 func TestNodeStop_ResetsRole(t *testing.T) {
 	port := freePort(t)
-	n := NewNode(port, "test")
+	n := NewNode("127.0.0.1", port, "test")
 
 	if err := n.BecomeLeader(); err != nil {
 		t.Fatalf("BecomeLeader: %v", err)
@@ -140,7 +140,7 @@ func TestNodeStop_ResetsRole(t *testing.T) {
 }
 
 func TestNodeStop_Idempotent(t *testing.T) {
-	n := NewNode(19940, "test")
+	n := NewNode("127.0.0.1", 19940, "test")
 	n.Stop()
 	n.Stop() // should not panic
 }

--- a/internal/tools_handler_test.go
+++ b/internal/tools_handler_test.go
@@ -15,7 +15,7 @@ import (
 func newTestServer(t *testing.T) (*server.MCPServer, *Node) {
 	t.Helper()
 	s := server.NewMCPServer("test", "0.0.1")
-	node := NewNode(19940, "test")
+	node := NewNode("127.0.0.1", 19940, "test")
 	RegisterTools(s, node)
 	RegisterPrompts(s)
 	return s, node
@@ -41,7 +41,7 @@ func callTool(t *testing.T, s *server.MCPServer, name string, args map[string]an
 
 func TestRegisterTools_Smoke(t *testing.T) {
 	s := server.NewMCPServer("test", "0.0.1")
-	RegisterTools(s, NewNode(19940, "test"))
+	RegisterTools(s, NewNode("127.0.0.1", 19940, "test"))
 }
 
 func TestRegisterPrompts_Smoke(t *testing.T) {
@@ -52,7 +52,7 @@ func TestRegisterPrompts_Smoke(t *testing.T) {
 // ── makeHandler ───────────────────────────────────────────────────────────────
 
 func TestMakeHandler_UnknownNode(t *testing.T) {
-	node := NewNode(19940, "test")
+	node := NewNode("127.0.0.1", 19940, "test")
 	handler := makeHandler(node, "get_document", nil, nil)
 	result, err := handler(context.Background(), mcp.CallToolRequest{})
 	if err != nil {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -6,8 +6,8 @@
   "ui": "dist/index.html",
   "permissions": [],
   "networkAccess": {
-    "allowedDomains": ["ws://localhost:1994", "https://avatars.githubusercontent.com"],
-    "reasoning": "Connects to local MCP server via WebSocket to stream Figma document data to AI tools"
+    "allowedDomains": ["*"],
+    "reasoning": "The server host and port are user-configurable (defaults to ws://127.0.0.1:1994), so any origin must be allowed to support custom addresses"
   },
   "documentAccess": "dynamic-page",
   "editorType": ["figma", "dev"],

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -17,8 +17,7 @@ const sendStatus = () => {
 const handleRequest = async (request: any) => {
   try {
     const result =
-      (await handleReadRequest(request)) ??
-      (await handleWriteRequest(request));
+      (await handleReadRequest(request)) ?? (await handleWriteRequest(request));
     if (result === null)
       throw new Error(`Unknown request type: ${request.type}`);
     return result;
@@ -31,7 +30,7 @@ const handleRequest = async (request: any) => {
   }
 };
 
-figma.showUI(__html__, { width: 320, height: 210 });
+figma.showUI(__html__, { width: 320, height: 230 });
 sendStatus();
 
 figma.on("selectionchange", () => {
@@ -45,6 +44,22 @@ figma.on("currentpagechange", () => {
 figma.ui.onmessage = async (message) => {
   if (message.type === "ui-ready") {
     sendStatus();
+    return;
+  }
+  if (message.type === "get_ws_config") {
+    const config = await figma.clientStorage.getAsync("ws_config");
+    figma.ui.postMessage({
+      type: "ws_config",
+      host: config?.host ?? "127.0.0.1",
+      port: config?.port ?? "1994",
+    });
+    return;
+  }
+  if (message.type === "save_ws_config") {
+    await figma.clientStorage.setAsync("ws_config", {
+      host: message.host,
+      port: message.port,
+    });
     return;
   }
   if (message.type === "server-request") {

--- a/plugin/src/ui/App.svelte
+++ b/plugin/src/ui/App.svelte
@@ -8,22 +8,40 @@
   let activeRequests = new Set<string>();
   $: isWorking = activeRequests.size > 0;
 
-  const WS_URL = "ws://localhost:1994/ws";
+  // Configurable server address.
+  // Persisted via figma.clientStorage (through plugin core) because localStorage
+  // is unavailable inside Figma's data: URL sandbox.
+  let serverHost = "127.0.0.1";
+  let serverPort = "1994";
+
+  let showSettings = false;
+  let editHost = serverHost;
+  let editPort = serverPort;
+
   const RECONNECT_DELAY_MS = 1500;
 
   let socket: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let configLoaded = false;
 
   function connect() {
-    if (socket) socket.close();
-    socket = new WebSocket(WS_URL);
+    // Detach the old handler before closing so its onclose doesn't fire
+    // after we've already assigned a new socket, which would null out the
+    // new reference and silently break the connection.
+    if (socket) {
+      socket.onclose = null;
+      socket.close();
+    }
+    const ws = new WebSocket(`ws://${serverHost}:${serverPort}/ws`);
+    socket = ws;
 
-    socket.onopen = () => {
+    ws.onopen = () => {
       connected = true;
       parent.postMessage({ pluginMessage: { type: "ui-ready" } }, "*");
     };
 
-    socket.onclose = () => {
+    ws.onclose = () => {
+      if (socket !== ws) return; // stale handler — a newer connect() already took over
       connected = false;
       socket = null;
       activeRequests.clear();
@@ -36,11 +54,11 @@
       }
     };
 
-    socket.onerror = () => {
+    ws.onerror = () => {
       connected = false;
     };
 
-    socket.onmessage = (event) => {
+    ws.onmessage = (event) => {
       try {
         const payload = JSON.parse(event.data);
         if (payload.requestId) {
@@ -57,6 +75,16 @@
   function handleMessage(event: MessageEvent) {
     const msg = event.data?.pluginMessage;
     if (!msg) return;
+
+    if (msg.type === "ws_config") {
+      serverHost = msg.host ?? "127.0.0.1";
+      serverPort = msg.port ?? "1994";
+      if (!configLoaded) {
+        configLoaded = true;
+        connect();
+      }
+      return;
+    }
 
     if (msg.type === "plugin-status") {
       fileName = msg.payload.fileName;
@@ -76,11 +104,54 @@
     }
   }
 
+  function openSettings() {
+    editHost = serverHost;
+    editPort = serverPort;
+    showSettings = true;
+  }
+
+  function applySettings() {
+    serverHost = editHost.trim() || "127.0.0.1";
+    const p = parseInt(editPort, 10);
+    serverPort = p > 0 && p <= 65535 ? String(p) : "1994";
+    // Persist via plugin core (figma.clientStorage), since localStorage is
+    // unavailable in Figma's data: URL environment.
+    parent.postMessage(
+      { pluginMessage: { type: "save_ws_config", host: serverHost, port: serverPort } },
+      "*"
+    );
+    showSettings = false;
+    // Cancel any pending reconnect and reconnect immediately with the new address.
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    connect();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Enter") applySettings();
+    if (event.key === "Escape") showSettings = false;
+  }
+
   onMount(() => {
     window.addEventListener("message", handleMessage);
-    connect();
+
+    // Request stored config from plugin core (responds with ws_config message).
+    // connect() is called once we receive the response.
+    parent.postMessage({ pluginMessage: { type: "get_ws_config" } }, "*");
+
+    // Fallback: if the plugin core doesn't respond within 500 ms (e.g. during
+    // dev / hot-reload without a running core), connect with defaults.
+    const fallback = setTimeout(() => {
+      if (!configLoaded) {
+        configLoaded = true;
+        connect();
+      }
+    }, 500);
 
     return () => {
+      clearTimeout(fallback);
       window.removeEventListener("message", handleMessage);
       if (reconnectTimer !== null) clearTimeout(reconnectTimer);
       if (socket) socket.close();
@@ -110,32 +181,74 @@
     </div>
   {/if}
   <div class="footer">
-    <a
-      class="author"
-      href="https://github.com/vkhanhqui/figma-mcp-go"
-      target="_blank"
-    >
-      <img
-        src="https://avatars.githubusercontent.com/u/64468109?v=4"
-        alt="avatar"
-      />
-      vkhanhqui
-    </a>
-    <div class="footer-right">
-      <a
-        class="bug-report"
-        href="https://github.com/vkhanhqui/figma-mcp-go/issues/new"
-        target="_blank"
-        title="Report a bug"
-      >
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-          <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7-3.25v2.992l2.028.812.772-1.932-2.8-1.872ZM6.272 3.937 3.5 5.808l.772 1.932L6.3 6.928V3.873a.75.75 0 0 0-.028.064ZM8.75 9.75H7.25V11h1.5V9.75Zm0-5.5H7.25v4h1.5v-4Z"/>
-        </svg>
-        Bug report
-      </a>
+    <!-- Row 1: server address (left) + connection badge (right) -->
+    <div class="footer-row">
+      {#if showSettings}
+        <div class="settings-panel">
+          <input
+            class="addr-input"
+            bind:value={editHost}
+            placeholder="127.0.0.1"
+            on:keydown={handleKeydown}
+          />
+          <span class="addr-sep">:</span>
+          <input
+            class="port-input"
+            bind:value={editPort}
+            placeholder="1994"
+            on:keydown={handleKeydown}
+          />
+          <button class="apply-btn" on:click={applySettings} title="Apply">✓</button>
+          <button class="cancel-btn" on:click={() => showSettings = false} title="Cancel">✕</button>
+        </div>
+      {:else}
+        <button
+          class="server-addr"
+          on:click={openSettings}
+          title="Click to configure server address"
+        >{serverHost}:{serverPort}</button>
+      {/if}
       <div class="badge" class:connected class:disconnected={!connected}>
         <span class="dot" class:connected></span>
         <span>{connected ? "Connected" : "Disconnected"}</span>
+      </div>
+    </div>
+    <!-- Row 2: author (left) + bug report + feature suggestion (right) -->
+    <div class="footer-row">
+      <a
+        class="author"
+        href="https://github.com/vkhanhqui/figma-mcp-go"
+        target="_blank"
+      >
+        <img
+          src="https://avatars.githubusercontent.com/u/64468109?v=4"
+          alt="avatar"
+        />
+        vkhanhqui
+      </a>
+      <div class="links">
+        <a
+          class="footer-link"
+          href="https://github.com/vkhanhqui/figma-mcp-go/issues/new?labels=bug"
+          target="_blank"
+          title="Report a bug"
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7-3.25v2.992l2.028.812.772-1.932-2.8-1.872ZM6.272 3.937 3.5 5.808l.772 1.932L6.3 6.928V3.873a.75.75 0 0 0-.028.064ZM8.75 9.75H7.25V11h1.5V9.75Zm0-5.5H7.25v4h1.5v-4Z"/>
+          </svg>
+          Bug
+        </a>
+        <a
+          class="footer-link"
+          href="https://github.com/vkhanhqui/figma-mcp-go/issues/new?labels=enhancement&title=Feature+request%3A+"
+          target="_blank"
+          title="Suggest a feature"
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 14.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"/>
+          </svg>
+          Suggest
+        </a>
       </div>
     </div>
   </div>
@@ -219,17 +332,24 @@
 
   .footer {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .footer-right {
-    display: flex;
-    align-items: center;
+    flex-direction: column;
     gap: 8px;
   }
 
-  .bug-report {
+  .footer-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .links {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .footer-link {
     display: flex;
     align-items: center;
     gap: 4px;
@@ -238,8 +358,8 @@
     font-size: 11px;
   }
 
-  .bug-report:hover {
-    color: #f87171;
+  .footer-link:hover {
+    color: #e0e0e0;
   }
 
   .author {
@@ -259,6 +379,94 @@
     width: 20px;
     height: 20px;
     border-radius: 50%;
+  }
+
+  /* Server address button — shows current host:port, click to edit */
+  .server-addr {
+    background: none;
+    border: none;
+    color: #666;
+    font-size: 10px;
+    font-family: monospace;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 4px;
+  }
+
+  .server-addr:hover {
+    color: #aaa;
+    background: #2a2a2a;
+  }
+
+  /* Inline settings panel — takes remaining space so inputs aren't squished */
+  .settings-panel {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+  }
+
+  .addr-input {
+    width: 72px;
+    background: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 4px;
+    color: #e0e0e0;
+    font-size: 10px;
+    font-family: monospace;
+    padding: 2px 4px;
+    outline: none;
+  }
+
+  .addr-input:focus {
+    border-color: #555;
+  }
+
+  .port-input {
+    width: 36px;
+    background: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 4px;
+    color: #e0e0e0;
+    font-size: 10px;
+    font-family: monospace;
+    padding: 2px 4px;
+    outline: none;
+  }
+
+  .port-input:focus {
+    border-color: #555;
+  }
+
+  .addr-sep {
+    color: #666;
+    font-size: 10px;
+  }
+
+  .apply-btn,
+  .cancel-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 11px;
+    padding: 1px 3px;
+    border-radius: 3px;
+  }
+
+  .apply-btn {
+    color: #4ade80;
+  }
+
+  .apply-btn:hover {
+    background: #1a3a2a;
+  }
+
+  .cancel-btn {
+    color: #f87171;
+  }
+
+  .cancel-btn:hover {
+    background: #3a1a1a;
   }
 
   .badge {


### PR DESCRIPTION
## Summary
- Add `--ip` (default `127.0.0.1`) and `--port` (default `1994`) CLI flags to make the listen address configurable
- Thread the IP parameter through `NewNode`, `NewElection`, and `NewLeader` constructors
- Update all test call sites to pass the new `ip` parameter

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes