### PR TITLE
Fix: Replace synchronous Figma API calls with async-compatible methods

### DIFF
--- a/plugin/src/write-components.test.ts
+++ b/plugin/src/write-components.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
   mockNodes = {};
   (globalThis as any).figma = {
     get currentPage() { return { id: "0:1", name: "Page 1" }; },
-    set currentPage(page: any) { navigatedTo = page; },
+    setCurrentPageAsync: async (page: any) => { navigatedTo = page; },
     getNodeByIdAsync: async (id: string) => mockNodes[id] ?? null,
     group: (nodes: any[], parent: any) => {
       const group = { id: "grp:1", name: "Group 1", type: "GROUP", children: [...nodes] };

--- a/plugin/src/write-components.ts
+++ b/plugin/src/write-components.ts
@@ -67,7 +67,7 @@ export const handleWriteComponentRequest = async (request: any) => {
       } else {
         throw new Error("pageId or pageName is required");
       }
-      figma.currentPage = page;
+      await figma.setCurrentPageAsync(page);
       return {
         type: request.type,
         requestId: request.requestId,

--- a/plugin/src/write-styles.ts
+++ b/plugin/src/write-styles.ts
@@ -188,7 +188,7 @@ export const handleWriteStyleRequest = async (request: any) => {
         }
         case "TEXT":
           if (!("textStyleId" in node)) throw new Error(`Node ${nodeId} does not support text styles`);
-          n.textStyleId = p.styleId;
+          await n.setTextStyleIdAsync(p.styleId);          
           break;
         case "EFFECT":
           if (!("effectStyleId" in node)) throw new Error(`Node ${nodeId} does not support effect styles`);

--- a/plugin/src/write-styles.ts
+++ b/plugin/src/write-styles.ts
@@ -188,7 +188,7 @@ export const handleWriteStyleRequest = async (request: any) => {
         }
         case "TEXT":
           if (!("textStyleId" in node)) throw new Error(`Node ${nodeId} does not support text styles`);
-          await n.setTextStyleIdAsync(p.styleId);          
+          await n.setTextStyleIdAsync(p.styleId);
           break;
         case "EFFECT":
           if (!("effectStyleId" in node)) throw new Error(`Node ${nodeId} does not support effect styles`);


### PR DESCRIPTION
## 🔧 Summary

This PR updates legacy synchronous Figma plugin API calls to their async-safe counterparts in the figma-mcp-go layer to ensure compatibility with the latest Figma plugin execution model.

## 🚨 Problem

Some plugin operations were using deprecated or synchronous-style assignments, which can lead to inconsistent state updates or runtime issues in modern Figma plugin environments.

Example of outdated usage:
```
n.textStyleId = p.styleId;
figma.currentPage = page;
```
## ✅ Solution

- Replaced direct property assignments with their async equivalents:
```
await n.setTextStyleIdAsync(p.styleId);
await figma.setCurrentPageAsync(page);
```
## 🧠 Impact
- Ensures compatibility with Figma’s async plugin API constraints
- Prevents race conditions when updating node styles or page context
- Improves reliability of MCP-driven operations
- Aligns codebase with recommended Figma plugin patterns
## 🧪 Notes
- No behavioral changes intended
- Only internal API usage updated
- Safe to deploy without migration steps