### PR TITLE
feat(plugin): include `visible` and `opacity` properties in base node…

### DIFF
--- a/plugin/src/serializers.ts
+++ b/plugin/src/serializers.ts
@@ -143,13 +143,15 @@ export const serializeText = async (node: any, base: any) => {
 
 export const serializeNode = async (node: any): Promise<any> => {
   const styles = await serializeStyles(node);
-  const base = {
+  const base: any = {
     id: node.id,
     name: node.name,
     type: node.type,
     bounds: getBounds(node),
     styles,
   };
+  if ("opacity" in node && node.opacity !== 1) base.opacity = node.opacity;
+  if ("visible" in node && !node.visible) base.visible = false;
   if (node.type === "TEXT") return serializeText(node, base);
   if ("children" in node) {
     return Object.assign({}, base, {


### PR DESCRIPTION
## 🔧 Summary
This PR updates the core serialization logic (`serializeNode`) to explicitly include `visible` and `opacity` properties for all node outputs. It ensures LLMs reading the design context can accurately identify hidden elements.

## 🚨 Problem
Currently, when tools like `get_node` or `get_design_context` (under the default `detail="full"` mode) return node JSON, they omit the Figma node's `visible` state.
Because designers frequently leave hidden deprecated layers, placeholder buttons, or alternate design states in a Frame, the LLMs end up reading these invisible nodes and generating cluttered, overlapping UI code. Users currently have to manually compare screenshots to filter them out.

## ✅ Solution
* Updated the base `serializeNode` function in `plugin/src/serializers.ts` to natively check and append `visible: false` and non-default `opacity`.
* To keep the JSON lightweight, these properties are only included when their values diverge from the default (i.e. `visible === false` or `opacity !== 1`).

## 🧠 Impact
* AI agents and MCP tools will now accurately see which Figma nodes are actually hidden on the canvas.
* Prevents the generation of redundant code for hidden or alternate state layers.
* Aligns the output of `get_node` and full design context with the expectations of UI-to-Code automation workflows.

## 🧪 Notes
* Backward compatible: No breaking changes to existing node properties or the `compact` detail mode.
* Only the base serializer was updated to ensure minimal diff and universal support across all read operations.