### PR TITLE
feat: surface effects, text truncation, and linked instancesFeat/effects truncation instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Open-source Figma MCP server with full read/write access via plugin — no REST 
 **Highlights**
 - No Figma API token required
 - No rate limits — free plan friendly
-- **Read and Write** live Figma data via plugin bridge — 73 tools total
+- **Read and Write** live Figma data via plugin bridge — 74 tools total
 - Full design automation — styles, variables, components, prototypes, and content
 - Design strategies included — read_design_strategy, design_strategy, and more prompts built in
 
@@ -112,6 +112,7 @@ codex mcp add figma-mcp-go -- npx -y @vkhanhqui/figma-mcp-go@latest
 | `create_text` | Create a text node (font loaded automatically) |
 | `import_image` | Decode base64 image and place it as a rectangle fill |
 | `create_component` | Convert an existing FRAME node into a reusable component |
+| `create_instance` | Create a linked INSTANCE of a COMPONENT or COMPONENT_SET (in-file or imported via library key). Stays linked to the main component, unlike `clone_node` |
 | `create_section` | Create a Figma Section node to organise frames on a page |
 
 ### Write — Modify

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -280,8 +280,14 @@ func ValidateRPC(tool string, nodeIDs []string, params map[string]interface{}) s
 		if !ValidNodeID(nodeIDs[0]) {
 			return fmt.Sprintf("nodeId must use colon format e.g. 4029:12345, got: %s", nodeIDs[0])
 		}
-		if _, ok := params["text"].(string); !ok {
-			return "text is required"
+		_, hasText := params["text"].(string)
+		_, hasTrunc := params["textTruncation"]
+		_, hasMaxLines := params["maxLines"]
+		if !hasText && !hasTrunc && !hasMaxLines {
+			return "at least one of text, textTruncation, or maxLines is required"
+		}
+		if tt, ok := params["textTruncation"].(string); ok && tt != "DISABLED" && tt != "ENDING" {
+			return fmt.Sprintf("textTruncation must be 'DISABLED' or 'ENDING', got: %s", tt)
 		}
 
 	case "set_fills":

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -220,6 +220,22 @@ func ValidateRPC(tool string, nodeIDs []string, params map[string]interface{}) s
 			return fmt.Sprintf("nodeId must use colon format e.g. 4029:12345, got: %s", nodeIDs[0])
 		}
 
+	case "create_instance":
+		componentID, _ := params["componentId"].(string)
+		componentKey, _ := params["componentKey"].(string)
+		if componentID == "" && componentKey == "" {
+			return "componentId or componentKey is required"
+		}
+		if componentID != "" && componentKey != "" {
+			return "componentId and componentKey are mutually exclusive — provide one"
+		}
+		if componentID != "" && !ValidNodeID(componentID) {
+			return fmt.Sprintf("componentId must use colon format e.g. 4029:12345, got: %s", componentID)
+		}
+		if pid, ok := params["parentId"].(string); ok && pid != "" && !ValidNodeID(pid) {
+			return fmt.Sprintf("parentId must use colon format e.g. 4029:12345, got: %s", pid)
+		}
+
 	case "export_tokens":
 		if format, ok := params["format"].(string); ok && format != "" {
 			switch format {

--- a/internal/schema_test.go
+++ b/internal/schema_test.go
@@ -825,6 +825,46 @@ func TestValidateRPC_CreateComponent(t *testing.T) {
 	}
 }
 
+func TestValidateRPC_CreateInstance(t *testing.T) {
+	// missing both componentId and componentKey
+	if msg := ValidateRPC("create_instance", nil, nil); msg == "" {
+		t.Error("expected error when neither componentId nor componentKey provided")
+	}
+	if msg := ValidateRPC("create_instance", nil, map[string]interface{}{}); msg == "" {
+		t.Error("expected error for empty params")
+	}
+	// both provided — mutually exclusive
+	if msg := ValidateRPC("create_instance", nil, map[string]interface{}{
+		"componentId": "1:1", "componentKey": "abc",
+	}); msg == "" {
+		t.Error("expected error when both componentId and componentKey provided")
+	}
+	// invalid componentId format
+	if msg := ValidateRPC("create_instance", nil, map[string]interface{}{"componentId": "bad-id"}); msg == "" {
+		t.Error("expected error for hyphen componentId")
+	}
+	// invalid parentId format
+	if msg := ValidateRPC("create_instance", nil, map[string]interface{}{
+		"componentId": "1:1", "parentId": "bad",
+	}); msg == "" {
+		t.Error("expected error for invalid parentId")
+	}
+	// valid: componentId only
+	if msg := ValidateRPC("create_instance", nil, map[string]interface{}{"componentId": "1:1"}); msg != "" {
+		t.Errorf("unexpected error: %s", msg)
+	}
+	// valid: componentKey only
+	if msg := ValidateRPC("create_instance", nil, map[string]interface{}{"componentKey": "abc123"}); msg != "" {
+		t.Errorf("unexpected error: %s", msg)
+	}
+	// valid: componentId + parentId
+	if msg := ValidateRPC("create_instance", nil, map[string]interface{}{
+		"componentId": "1:1", "parentId": "2:2",
+	}); msg != "" {
+		t.Errorf("unexpected error: %s", msg)
+	}
+}
+
 func TestValidateRPC_ExportTokens(t *testing.T) {
 	// no params — valid (defaults to json)
 	if msg := ValidateRPC("export_tokens", nil, nil); msg != "" {

--- a/internal/schema_test.go
+++ b/internal/schema_test.go
@@ -214,13 +214,31 @@ func TestValidateRPC_SetText(t *testing.T) {
 	if msg := ValidateRPC("set_text", nil, map[string]interface{}{"text": "hello"}); msg == "" {
 		t.Error("expected error for missing nodeId")
 	}
-	// missing text
+	// no text, truncation, or maxLines
 	if msg := ValidateRPC("set_text", []string{"1:1"}, nil); msg == "" {
-		t.Error("expected error for missing text")
+		t.Error("expected error when no text/truncation/maxLines provided")
 	}
-	// valid
-	msg := ValidateRPC("set_text", []string{"1:1"}, map[string]interface{}{"text": "hello"})
-	if msg != "" {
+	if msg := ValidateRPC("set_text", []string{"1:1"}, map[string]interface{}{}); msg == "" {
+		t.Error("expected error when no text/truncation/maxLines provided (empty params)")
+	}
+	// invalid textTruncation
+	if msg := ValidateRPC("set_text", []string{"1:1"}, map[string]interface{}{"textTruncation": "TRUNCATE"}); msg == "" {
+		t.Error("expected error for invalid textTruncation")
+	}
+	// valid: text only
+	if msg := ValidateRPC("set_text", []string{"1:1"}, map[string]interface{}{"text": "hello"}); msg != "" {
+		t.Errorf("unexpected error: %s", msg)
+	}
+	// valid: textTruncation only
+	if msg := ValidateRPC("set_text", []string{"1:1"}, map[string]interface{}{"textTruncation": "ENDING"}); msg != "" {
+		t.Errorf("unexpected error: %s", msg)
+	}
+	// valid: maxLines only
+	if msg := ValidateRPC("set_text", []string{"1:1"}, map[string]interface{}{"maxLines": float64(2)}); msg != "" {
+		t.Errorf("unexpected error: %s", msg)
+	}
+	// valid: maxLines = nil (clear)
+	if msg := ValidateRPC("set_text", []string{"1:1"}, map[string]interface{}{"maxLines": nil}); msg != "" {
 		t.Errorf("unexpected error: %s", msg)
 	}
 }

--- a/internal/tools_schema_test.go
+++ b/internal/tools_schema_test.go
@@ -106,7 +106,7 @@ func TestToolSchemas_ArrayItemsHaveType(t *testing.T) {
 // accidentally dropped registrations are caught.
 func TestToolSchemas_AllToolsRegistered(t *testing.T) {
 	resp := listTools(t)
-	const want = 73
+	const want = 74
 	got := len(resp.Result.Tools)
 	if got != want {
 		t.Errorf("expected %d registered tools, got %d — update the constant if tools were intentionally added or removed", want, got)

--- a/internal/tools_write_create.go
+++ b/internal/tools_write_create.go
@@ -80,6 +80,8 @@ func registerWriteCreateTools(s *server.MCPServer, node *Node) {
 		mcp.WithString("fillColor", mcp.Description("Text color as hex e.g. #000000 (default black)")),
 		mcp.WithString("name", mcp.Description("Node name shown in the layers panel (defaults to the text content)")),
 		mcp.WithString("parentId", mcp.Description("Parent node ID in colon format. Defaults to current page.")),
+		mcp.WithString("textTruncation", mcp.Description("Truncation behaviour: 'DISABLED' (default, no truncation) or 'ENDING' (truncate with an ellipsis)")),
+		mcp.WithNumber("maxLines", mcp.Description("Maximum number of lines before truncation (positive integer). Only applies when textTruncation is 'ENDING'.")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		params := req.GetArguments()
 		resp, err := node.Send(ctx, "create_text", nil, params)

--- a/internal/tools_write_create.go
+++ b/internal/tools_write_create.go
@@ -148,6 +148,21 @@ func registerWriteCreateTools(s *server.MCPServer, node *Node) {
 		return renderResponse(resp, err)
 	})
 
+	s.AddTool(mcp.NewTool("create_instance",
+		mcp.WithDescription("Create a linked INSTANCE of a COMPONENT or COMPONENT_SET. Unlike clone_node (which makes an independent copy), an instance stays connected to its main component — edits to the main component propagate to all its instances. Pass componentId for a component in the current file, or componentKey to import a published library component from another file. For variant sets, pass variantProperties to pick a specific variant (otherwise the default variant is used)."),
+		mcp.WithString("componentId", mcp.Description("ID of a COMPONENT or COMPONENT_SET in the current file, in colon format e.g. '4029:12345'. Mutually exclusive with componentKey.")),
+		mcp.WithString("componentKey", mcp.Description("Published component key — used to import a component from another file's library. Find it via get_local_components on the source file or in Figma's library panel.")),
+		mcp.WithObject("variantProperties", mcp.Description("When componentId points to a COMPONENT_SET, an object of variant property name → value pairs to select which variant to instantiate (e.g. { \"Size\": \"Large\", \"State\": \"Hover\" }). If omitted, the default variant is used.")),
+		mcp.WithNumber("x", mcp.Description("X position in pixels (default 0)")),
+		mcp.WithNumber("y", mcp.Description("Y position in pixels (default 0)")),
+		mcp.WithString("name", mcp.Description("Optional name for the instance (defaults to the component's name)")),
+		mcp.WithString("parentId", mcp.Description("Parent node ID in colon format. Defaults to the current page.")),
+	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		params := req.GetArguments()
+		resp, err := node.Send(ctx, "create_instance", nil, params)
+		return renderResponse(resp, err)
+	})
+
 	s.AddTool(mcp.NewTool("create_section",
 		mcp.WithDescription("Create a Figma Section node on the current page. Sections are the modern way to organize frames and groups on a page."),
 		mcp.WithString("name", mcp.Description("Section name (default 'Section')")),

--- a/internal/tools_write_modify.go
+++ b/internal/tools_write_modify.go
@@ -9,19 +9,32 @@ import (
 
 func registerWriteModifyTools(s *server.MCPServer, node *Node) {
 	s.AddTool(mcp.NewTool("set_text",
-		mcp.WithDescription("Update the text content of an existing TEXT node."),
+		mcp.WithDescription("Update the text content and/or truncation behaviour of an existing TEXT node. At least one of text, textTruncation, or maxLines must be provided."),
 		mcp.WithString("nodeId",
 			mcp.Required(),
 			mcp.Description("TEXT node ID in colon format e.g. '4029:12345'"),
 		),
-		mcp.WithString("text",
-			mcp.Required(),
-			mcp.Description("New text content"),
-		),
+		mcp.WithString("text", mcp.Description("New text content (optional — omit to keep the existing characters)")),
+		mcp.WithString("textTruncation", mcp.Description("Truncation behaviour: 'DISABLED' (no truncation) or 'ENDING' (truncate with an ellipsis)")),
+		mcp.WithNumber("maxLines", mcp.Description("Maximum number of lines before truncation (positive integer). Only applies when textTruncation is 'ENDING'. Pass 0 to clear the cap (interpreted as null).")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		nodeID, _ := req.GetArguments()["nodeId"].(string)
-		text, _ := req.GetArguments()["text"].(string)
-		resp, err := node.Send(ctx, "set_text", []string{nodeID}, map[string]interface{}{"text": text})
+		args := req.GetArguments()
+		nodeID, _ := args["nodeId"].(string)
+		params := map[string]interface{}{}
+		if t, ok := args["text"].(string); ok {
+			params["text"] = t
+		}
+		if tt, ok := args["textTruncation"].(string); ok && tt != "" {
+			params["textTruncation"] = tt
+		}
+		if ml, ok := args["maxLines"].(float64); ok {
+			if ml == 0 {
+				params["maxLines"] = nil
+			} else {
+				params["maxLines"] = ml
+			}
+		}
+		resp, err := node.Send(ctx, "set_text", []string{nodeID}, params)
 		return renderResponse(resp, err)
 	})
 

--- a/internal/tools_write_styles.go
+++ b/internal/tools_write_styles.go
@@ -40,6 +40,8 @@ func registerWriteStyleTools(s *server.MCPServer, node *Node) {
 		mcp.WithNumber("letterSpacingValue", mcp.Description("Letter spacing value (unit set by letterSpacingUnit)")),
 		mcp.WithString("letterSpacingUnit", mcp.Description("Letter spacing unit: PIXELS (default) or PERCENT")),
 		mcp.WithString("description", mcp.Description("Optional human-readable description shown in the Figma style panel")),
+		mcp.WithString("textTruncation", mcp.Description("Truncation behaviour: 'DISABLED' (default) or 'ENDING' (truncate with an ellipsis)")),
+		mcp.WithNumber("maxLines", mcp.Description("Maximum number of lines before truncation (positive integer). Only applies when textTruncation is 'ENDING'.")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		params := req.GetArguments()
 		resp, err := node.Send(ctx, "create_text_style", nil, params)

--- a/plugin/src/read-document.ts
+++ b/plugin/src/read-document.ts
@@ -354,13 +354,26 @@ export const handleReadDocumentRequest = async (request: any) => {
       const textNodes: any[] = [];
       const findText = async (n: any) => {
         if (n.type === "TEXT") {
-          textNodes.push({
+          const entry: any = {
             id: n.id,
             name: n.name,
             characters: n.characters,
             fontSize: isMixed(n.fontSize) ? "mixed" : n.fontSize,
             fontName: isMixed(n.fontName) ? "mixed" : n.fontName,
-          });
+          };
+          const trunc = isMixed(n.textTruncation)
+            ? "mixed"
+            : n.textTruncation && n.textTruncation !== "DISABLED"
+              ? n.textTruncation
+              : undefined;
+          if (trunc !== undefined) entry.textTruncation = trunc;
+          const maxLines = isMixed(n.maxLines)
+            ? "mixed"
+            : n.maxLines != null
+              ? n.maxLines
+              : undefined;
+          if (maxLines !== undefined) entry.maxLines = maxLines;
+          textNodes.push(entry);
         }
         if ("children" in n)
           for (const child of n.children) await findText(child);

--- a/plugin/src/read-styles.ts
+++ b/plugin/src/read-styles.ts
@@ -19,17 +19,24 @@ export const handleReadStyleRequest = async (request: any) => {
             name: s.name,
             paints: s.paints,
           })),
-          text: textStyles.map((s) => ({
-            id: s.id,
-            name: s.name,
-            fontSize: s.fontSize,
-            fontFamily: s.fontName ? s.fontName.family : undefined,
-            fontStyle: s.fontName ? s.fontName.style : undefined,
-            textDecoration:
-              s.textDecoration !== "NONE" ? s.textDecoration : undefined,
-            lineHeight: (s as any).lineHeight,
-            letterSpacing: (s as any).letterSpacing,
-          })),
+          text: textStyles.map((s) => {
+            const entry: any = {
+              id: s.id,
+              name: s.name,
+              fontSize: s.fontSize,
+              fontFamily: s.fontName ? s.fontName.family : undefined,
+              fontStyle: s.fontName ? s.fontName.style : undefined,
+              textDecoration:
+                s.textDecoration !== "NONE" ? s.textDecoration : undefined,
+              lineHeight: (s as any).lineHeight,
+              letterSpacing: (s as any).letterSpacing,
+            };
+            const trunc = (s as any).textTruncation;
+            if (trunc && trunc !== "DISABLED") entry.textTruncation = trunc;
+            const maxLines = (s as any).maxLines;
+            if (maxLines != null) entry.maxLines = maxLines;
+            return entry;
+          }),
           effects: effectStyles.map((s) => ({
             id: s.id,
             name: s.name,

--- a/plugin/src/serializers.test.ts
+++ b/plugin/src/serializers.test.ts
@@ -637,6 +637,60 @@ describe("serializeText", () => {
     const result = await serializeText(node, makeBase());
     expect(result.styles.textDecoration).toBe("UNDERLINE");
   });
+
+  it("omits textTruncation when DISABLED and maxLines when null", async () => {
+    const node = {
+      fontName: { family: "Inter", style: "Regular" },
+      fontSize: 14,
+      fontWeight: 400,
+      textDecoration: "NONE",
+      lineHeight: { unit: "AUTO" },
+      letterSpacing: { value: 0, unit: "PIXELS" },
+      textAlignHorizontal: "LEFT",
+      characters: "plain",
+      textTruncation: "DISABLED",
+      maxLines: null,
+    };
+    const result = await serializeText(node, makeBase());
+    expect(result.styles.textTruncation).toBeUndefined();
+    expect(result.styles.maxLines).toBeUndefined();
+  });
+
+  it("includes textTruncation and maxLines when set", async () => {
+    const node = {
+      fontName: { family: "Inter", style: "Regular" },
+      fontSize: 14,
+      fontWeight: 400,
+      textDecoration: "NONE",
+      lineHeight: { unit: "AUTO" },
+      letterSpacing: { value: 0, unit: "PIXELS" },
+      textAlignHorizontal: "LEFT",
+      characters: "truncated content here",
+      textTruncation: "ENDING",
+      maxLines: 2,
+    };
+    const result = await serializeText(node, makeBase());
+    expect(result.styles.textTruncation).toBe("ENDING");
+    expect(result.styles.maxLines).toBe(2);
+  });
+
+  it("emits 'mixed' for mixed textTruncation/maxLines", async () => {
+    const node = {
+      fontName: { family: "Inter", style: "Regular" },
+      fontSize: 14,
+      fontWeight: 400,
+      textDecoration: "NONE",
+      lineHeight: { unit: "AUTO" },
+      letterSpacing: { value: 0, unit: "PIXELS" },
+      textAlignHorizontal: "LEFT",
+      characters: "mixed",
+      textTruncation: Symbol(),
+      maxLines: Symbol(),
+    };
+    const result = await serializeText(node, makeBase());
+    expect(result.styles.textTruncation).toBe("mixed");
+    expect(result.styles.maxLines).toBe("mixed");
+  });
 });
 
 // ── serializeNode ─────────────────────────────────────────────────────────────

--- a/plugin/src/serializers.test.ts
+++ b/plugin/src/serializers.test.ts
@@ -3,6 +3,7 @@ import {
   isMixed,
   toHex,
   serializePaints,
+  serializeEffects,
   getBounds,
   deduplicateStyles,
   serializeVariableValue,
@@ -102,6 +103,123 @@ describe("serializePaints", () => {
   });
 });
 
+// ── serializeEffects ──────────────────────────────────────────────────────────
+
+describe("serializeEffects", () => {
+  it("returns 'mixed' for symbol input", () => {
+    expect(serializeEffects(Symbol())).toBe("mixed");
+  });
+
+  it("returns undefined for null/non-array", () => {
+    expect(serializeEffects(null)).toBeUndefined();
+    expect(serializeEffects("nope")).toBeUndefined();
+  });
+
+  it("returns undefined for empty array", () => {
+    expect(serializeEffects([])).toBeUndefined();
+  });
+
+  it("serializes a drop shadow with hex color and split offset", () => {
+    const effects = [
+      {
+        type: "DROP_SHADOW",
+        color: { r: 0, g: 0, b: 0, a: 0.25 },
+        offset: { x: 0, y: 4 },
+        radius: 8,
+        spread: 0,
+        visible: true,
+        blendMode: "NORMAL",
+      },
+    ];
+    expect(serializeEffects(effects)).toEqual([
+      {
+        type: "DROP_SHADOW",
+        color: "#000000",
+        opacity: 0.25,
+        offsetX: 0,
+        offsetY: 4,
+        radius: 8,
+        spread: 0,
+      },
+    ]);
+  });
+
+  it("serializes an inner shadow", () => {
+    const effects = [
+      {
+        type: "INNER_SHADOW",
+        color: { r: 1, g: 1, b: 1, a: 0.5 },
+        offset: { x: -2, y: 2 },
+        radius: 4,
+        spread: 1,
+        visible: true,
+        blendMode: "NORMAL",
+      },
+    ];
+    const result = serializeEffects(effects) as any[];
+    expect(result[0].type).toBe("INNER_SHADOW");
+    expect(result[0].color).toBe("#ffffff");
+    expect(result[0].opacity).toBe(0.5);
+    expect(result[0].offsetX).toBe(-2);
+    expect(result[0].offsetY).toBe(2);
+  });
+
+  it("preserves non-NORMAL blend mode and visible: false", () => {
+    const effects = [
+      {
+        type: "DROP_SHADOW",
+        color: { r: 0, g: 0, b: 0, a: 1 },
+        offset: { x: 0, y: 0 },
+        radius: 0,
+        spread: 0,
+        visible: false,
+        blendMode: "MULTIPLY",
+      },
+    ];
+    const result = serializeEffects(effects) as any[];
+    expect(result[0].blendMode).toBe("MULTIPLY");
+    expect(result[0].visible).toBe(false);
+  });
+
+  it("omits NORMAL blendMode and visible when true", () => {
+    const effects = [
+      {
+        type: "DROP_SHADOW",
+        color: { r: 0, g: 0, b: 0, a: 1 },
+        offset: { x: 0, y: 4 },
+        radius: 4,
+        spread: 0,
+        visible: true,
+        blendMode: "NORMAL",
+      },
+    ];
+    const result = serializeEffects(effects) as any[];
+    expect(result[0].blendMode).toBeUndefined();
+    expect(result[0].visible).toBeUndefined();
+  });
+
+  it("serializes layer blur with just type and radius", () => {
+    const effects = [{ type: "LAYER_BLUR", radius: 12, visible: true }];
+    expect(serializeEffects(effects)).toEqual([{ type: "LAYER_BLUR", radius: 12 }]);
+  });
+
+  it("serializes background blur", () => {
+    const effects = [{ type: "BACKGROUND_BLUR", radius: 20, visible: true }];
+    expect(serializeEffects(effects)).toEqual([{ type: "BACKGROUND_BLUR", radius: 20 }]);
+  });
+
+  it("serializes multiple effects in order", () => {
+    const effects = [
+      { type: "DROP_SHADOW", color: { r: 0, g: 0, b: 0, a: 0.1 }, offset: { x: 0, y: 1 }, radius: 2, spread: 0, visible: true, blendMode: "NORMAL" },
+      { type: "DROP_SHADOW", color: { r: 0, g: 0, b: 0, a: 0.2 }, offset: { x: 0, y: 4 }, radius: 8, spread: 0, visible: true, blendMode: "NORMAL" },
+    ];
+    const result = serializeEffects(effects) as any[];
+    expect(result).toHaveLength(2);
+    expect(result[0].opacity).toBe(0.1);
+    expect(result[1].opacity).toBe(0.2);
+  });
+});
+
 // ── getBounds ─────────────────────────────────────────────────────────────────
 
 describe("getBounds", () => {
@@ -190,6 +308,22 @@ describe("deduplicateStyles", () => {
     const children = (result as any).children;
     expect(typeof children[0].styles.fills).toBe("string");
     expect(children[0].styles.fills).toBe(children[1].styles.fills);
+  });
+
+  it("deduplicates effects that appear more than once", () => {
+    const sharedEffect = [{ type: "DROP_SHADOW", color: "#000000", opacity: 0.1, offsetX: 0, offsetY: 4, radius: 8, spread: 0 }];
+    const tree = {
+      children: [
+        { styles: { effects: sharedEffect } },
+        { styles: { effects: sharedEffect } },
+      ],
+    };
+    const { tree: result, globalVars } = deduplicateStyles(tree);
+    expect(globalVars).toBeDefined();
+    expect(Object.keys(globalVars!.styles).length).toBe(1);
+    const children = (result as any).children;
+    expect(typeof children[0].styles.effects).toBe("string");
+    expect(children[0].styles.effects).toBe(children[1].styles.effects);
   });
 
   it("deduplicates strokes that appear more than once", () => {
@@ -330,6 +464,58 @@ describe("serializeStyles", () => {
     const node = { paddingLeft: 10, paddingRight: 20, paddingTop: 5, paddingBottom: 15 };
     const result = await serializeStyles(node);
     expect(result.padding).toEqual({ top: 5, right: 20, bottom: 15, left: 10 });
+  });
+
+  it("includes effects when node has a drop shadow", async () => {
+    const node = {
+      effects: [
+        {
+          type: "DROP_SHADOW",
+          color: { r: 0, g: 0, b: 0, a: 0.1 },
+          offset: { x: 0, y: 4 },
+          radius: 8,
+          spread: 0,
+          visible: true,
+          blendMode: "NORMAL",
+        },
+      ],
+    };
+    const result = await serializeStyles(node);
+    expect(result.effects).toEqual([
+      {
+        type: "DROP_SHADOW",
+        color: "#000000",
+        opacity: 0.1,
+        offsetX: 0,
+        offsetY: 4,
+        radius: 8,
+        spread: 0,
+      },
+    ]);
+  });
+
+  it("includes effectStyle name when effectStyleId resolves", async () => {
+    mockGetStyleByIdAsync = async (id) => (id === "es-1" ? { name: "Elevation/Card" } : null);
+    const node = {
+      effects: [
+        { type: "LAYER_BLUR", radius: 4, visible: true },
+      ],
+      effectStyleId: "es-1",
+    };
+    const result = await serializeStyles(node);
+    expect(result.effectStyle).toBe("Elevation/Card");
+    expect(result.effects).toEqual([{ type: "LAYER_BLUR", radius: 4 }]);
+  });
+
+  it("omits effects when node has the property but the array is empty", async () => {
+    const result = await serializeStyles({ effects: [] });
+    expect(result.effects).toBeUndefined();
+    expect(result.effectStyle).toBeUndefined();
+  });
+
+  it("does not include effects when node lacks the property", async () => {
+    const result = await serializeStyles({ name: "no-effects" });
+    expect(result.effects).toBeUndefined();
   });
 });
 

--- a/plugin/src/serializers.ts
+++ b/plugin/src/serializers.ts
@@ -167,6 +167,17 @@ export const serializeText = async (node: any, base: any) => {
       ? ((await figma.getStyleByIdAsync(node.textStyleId))?.name ?? undefined)
       : undefined;
 
+  const truncation = isMixed(node.textTruncation)
+    ? "mixed"
+    : node.textTruncation && node.textTruncation !== "DISABLED"
+      ? node.textTruncation
+      : undefined;
+  const maxLines = isMixed(node.maxLines)
+    ? "mixed"
+    : node.maxLines != null
+      ? node.maxLines
+      : undefined;
+
   return Object.assign({}, base, {
     characters: node.characters,
     styles: Object.assign({}, base.styles, {
@@ -185,6 +196,8 @@ export const serializeText = async (node: any, base: any) => {
       textAlignHorizontal: isMixed(node.textAlignHorizontal)
         ? "mixed"
         : node.textAlignHorizontal,
+      ...(truncation !== undefined ? { textTruncation: truncation } : {}),
+      ...(maxLines !== undefined ? { maxLines } : {}),
     }),
   });
 };

--- a/plugin/src/serializers.ts
+++ b/plugin/src/serializers.ts
@@ -12,6 +12,45 @@ export const toHex = (color: any) => {
   return `#${[r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("")}`;
 };
 
+// serializeEffects converts a Figma Effect[] into a JSON-friendly shape that
+// mirrors the input shape accepted by the `set_effects` write tool — colors
+// as hex, alpha as `opacity`, offset split into offsetX/offsetY.
+export const serializeEffects = (effects: any) => {
+  if (isMixed(effects)) return "mixed";
+  if (!effects || !Array.isArray(effects)) return undefined;
+
+  const result = effects.map((e: any) => {
+    if (e.type === "DROP_SHADOW" || e.type === "INNER_SHADOW") {
+      const out: any = {
+        type: e.type,
+        color: e.color ? toHex(e.color) : undefined,
+        opacity: e.color && "a" in e.color ? e.color.a : undefined,
+        offsetX: e.offset ? e.offset.x : undefined,
+        offsetY: e.offset ? e.offset.y : undefined,
+        radius: e.radius,
+        spread: e.spread,
+        blendMode: e.blendMode && e.blendMode !== "NORMAL" ? e.blendMode : undefined,
+        visible: e.visible === false ? false : undefined,
+      };
+      // Strip undefined keys for compactness
+      for (const k of Object.keys(out)) if (out[k] === undefined) delete out[k];
+      return out;
+    }
+    if (e.type === "LAYER_BLUR" || e.type === "BACKGROUND_BLUR") {
+      const out: any = {
+        type: e.type,
+        radius: e.radius,
+        visible: e.visible === false ? false : undefined,
+      };
+      for (const k of Object.keys(out)) if (out[k] === undefined) delete out[k];
+      return out;
+    }
+    return e;
+  });
+
+  return result.length > 0 ? result : undefined;
+};
+
 export const serializePaints = (paints: any) => {
   if (isMixed(paints)) return "mixed";
 
@@ -67,6 +106,15 @@ export const serializeStyles = async (node: any) => {
     }
     const strokes = serializePaints(node.strokes);
     if (strokes !== undefined) styles.strokes = strokes;
+  }
+
+  if ("effects" in node) {
+    if (node.effectStyleId && typeof node.effectStyleId === "string") {
+      const style = await figma.getStyleByIdAsync(node.effectStyleId);
+      if (style) styles.effectStyle = style.name;
+    }
+    const effects = serializeEffects(node.effects);
+    if (effects !== undefined) styles.effects = effects;
   }
 
   if ("cornerRadius" in node) {
@@ -172,6 +220,7 @@ export const deduplicateStyles = (tree: any): { tree: any; globalVars: Record<st
     if (s) {
       if (Array.isArray(s.fills)) counts.set(JSON.stringify(s.fills), (counts.get(JSON.stringify(s.fills)) ?? 0) + 1);
       if (Array.isArray(s.strokes)) counts.set(JSON.stringify(s.strokes), (counts.get(JSON.stringify(s.strokes)) ?? 0) + 1);
+      if (Array.isArray(s.effects)) counts.set(JSON.stringify(s.effects), (counts.get(JSON.stringify(s.effects)) ?? 0) + 1);
     }
     if (Array.isArray(node.children)) node.children.forEach(countWalk);
   };
@@ -204,6 +253,10 @@ export const deduplicateStyles = (tree: any): { tree: any; globalVars: Record<st
       if (Array.isArray(s.strokes)) {
         const ref = keyToRef.get(JSON.stringify(s.strokes));
         if (ref) newStyles = { ...newStyles, strokes: ref };
+      }
+      if (Array.isArray(s.effects)) {
+        const ref = keyToRef.get(JSON.stringify(s.effects));
+        if (ref) newStyles = { ...newStyles, effects: ref };
       }
       if (newStyles !== s) result = { ...node, styles: newStyles };
     }

--- a/plugin/src/write-create.test.ts
+++ b/plugin/src/write-create.test.ts
@@ -198,3 +198,128 @@ describe("create_section", () => {
     expect(res?.data.id).toBe("section:new");
   });
 });
+
+// ── create_instance ───────────────────────────────────────────────────────────
+
+describe("create_instance", () => {
+  let createdInstances: any[];
+  let parentNode: any;
+  let importedKey: string | null;
+
+  const makeComponent = (overrides?: any) => ({
+    id: "comp:src",
+    name: "SourceComponent",
+    type: "COMPONENT",
+    key: "abc123def456",
+    createInstance() {
+      const inst = {
+        id: `inst:${createdInstances.length + 1}`,
+        name: this.name,
+        type: "INSTANCE",
+        x: 0, y: 0, width: 100, height: 100,
+      };
+      createdInstances.push(inst);
+      return inst;
+    },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    createdInstances = [];
+    importedKey = null;
+    parentNode = { id: "page:1", appendChild(c: any) { (this.children ||= []).push(c); }, children: [] };
+    (globalThis as any).figma = {
+      ...(globalThis as any).figma,
+      currentPage: parentNode,
+      getNodeByIdAsync: async (id: string) => mockNodes[id] ?? null,
+      importComponentByKeyAsync: async (key: string) => {
+        importedKey = key;
+        return makeComponent({ id: "lib:1", name: "LibComponent", key });
+      },
+      commitUndo: () => { commitUndoCalled = true; },
+    };
+  });
+
+  it("creates an instance from componentId pointing to a COMPONENT", async () => {
+    mockNodes["comp:src"] = makeComponent();
+    const res = await handleWriteCreateRequest(makeRequest("create_instance", [], { componentId: "comp:src" }));
+    expect(res?.data.type).toBe("INSTANCE");
+    expect(res?.data.mainComponentId).toBe("comp:src");
+    expect(res?.data.mainComponentKey).toBe("abc123def456");
+    expect(commitUndoCalled).toBe(true);
+    expect(parentNode.children).toHaveLength(1);
+  });
+
+  it("imports a library component by key", async () => {
+    const res = await handleWriteCreateRequest(makeRequest("create_instance", [], { componentKey: "abc123def456" }));
+    expect(importedKey).toBe("abc123def456");
+    expect(res?.data.mainComponentId).toBe("lib:1");
+    expect(res?.data.type).toBe("INSTANCE");
+  });
+
+  it("picks the default variant when given a COMPONENT_SET without variantProperties", async () => {
+    const variantA = makeComponent({ id: "v:a", name: "A", variantProperties: { Size: "Small" } });
+    const variantB = makeComponent({ id: "v:b", name: "B", variantProperties: { Size: "Large" } });
+    mockNodes["set:1"] = {
+      id: "set:1", name: "Button", type: "COMPONENT_SET",
+      children: [variantA, variantB],
+      defaultVariant: variantA,
+    };
+    const res = await handleWriteCreateRequest(makeRequest("create_instance", [], { componentId: "set:1" }));
+    expect(res?.data.mainComponentId).toBe("v:a");
+  });
+
+  it("picks the matching variant when variantProperties are provided", async () => {
+    const variantA = makeComponent({ id: "v:a", name: "A", variantProperties: { Size: "Small", State: "Default" } });
+    const variantB = makeComponent({ id: "v:b", name: "B", variantProperties: { Size: "Large", State: "Hover" } });
+    mockNodes["set:1"] = { id: "set:1", type: "COMPONENT_SET", children: [variantA, variantB] };
+    const res = await handleWriteCreateRequest(makeRequest("create_instance", [], {
+      componentId: "set:1",
+      variantProperties: { Size: "Large", State: "Hover" },
+    }));
+    expect(res?.data.mainComponentId).toBe("v:b");
+  });
+
+  it("rejects when no variant matches the requested properties", async () => {
+    const variantA = makeComponent({ id: "v:a", variantProperties: { Size: "Small" } });
+    mockNodes["set:1"] = { id: "set:1", type: "COMPONENT_SET", children: [variantA] };
+    await expect(
+      handleWriteCreateRequest(makeRequest("create_instance", [], {
+        componentId: "set:1",
+        variantProperties: { Size: "XL" },
+      })),
+    ).rejects.toThrow("No variant in set");
+  });
+
+  it("rejects an INSTANCE id with a clear message", async () => {
+    mockNodes["inst:1"] = { id: "inst:1", type: "INSTANCE" };
+    await expect(
+      handleWriteCreateRequest(makeRequest("create_instance", [], { componentId: "inst:1" })),
+    ).rejects.toThrow("is an INSTANCE, not a COMPONENT");
+  });
+
+  it("rejects unrelated node types", async () => {
+    mockNodes["frame:1"] = { id: "frame:1", type: "FRAME" };
+    await expect(
+      handleWriteCreateRequest(makeRequest("create_instance", [], { componentId: "frame:1" })),
+    ).rejects.toThrow("must be COMPONENT or COMPONENT_SET");
+  });
+
+  it("rejects when neither componentId nor componentKey is provided", async () => {
+    await expect(
+      handleWriteCreateRequest(makeRequest("create_instance", [], {})),
+    ).rejects.toThrow("componentId or componentKey is required");
+  });
+
+  it("applies x, y and name overrides", async () => {
+    mockNodes["comp:src"] = makeComponent();
+    const res = await handleWriteCreateRequest(makeRequest("create_instance", [], {
+      componentId: "comp:src", x: 50, y: 75, name: "Renamed",
+    }));
+    const inst = createdInstances[0];
+    expect(inst.x).toBe(50);
+    expect(inst.y).toBe(75);
+    expect(inst.name).toBe("Renamed");
+    expect(res?.data.name).toBe("Renamed");
+  });
+});

--- a/plugin/src/write-create.ts
+++ b/plugin/src/write-create.ts
@@ -166,6 +166,70 @@ export const handleWriteCreateRequest = async (request: any) => {
       };
     }
 
+    case "create_instance": {
+      const p = request.params || {};
+      const parent = await getParentNode(p.parentId);
+
+      let component: ComponentNode | null = null;
+
+      if (p.componentKey && typeof p.componentKey === "string") {
+        try {
+          component = await figma.importComponentByKeyAsync(p.componentKey);
+        } catch (err) {
+          throw new Error(`Failed to import component by key '${p.componentKey}': ${err instanceof Error ? err.message : String(err)}`);
+        }
+      } else if (p.componentId && typeof p.componentId === "string") {
+        const node = await figma.getNodeByIdAsync(p.componentId);
+        if (!node) throw new Error(`Component not found: ${p.componentId}`);
+        if (node.type === "COMPONENT") {
+          component = node as ComponentNode;
+        } else if (node.type === "COMPONENT_SET") {
+          // Pick a variant: explicit variantName/properties match, or the default (first child component).
+          const set = node as ComponentSetNode;
+          const variants = set.children.filter((c): c is ComponentNode => c.type === "COMPONENT");
+          if (variants.length === 0) throw new Error(`Component set ${p.componentId} has no variants`);
+          if (p.variantProperties && typeof p.variantProperties === "object") {
+            const wanted = p.variantProperties as Record<string, string>;
+            const match = variants.find((v) => {
+              const vp = v.variantProperties;
+              if (!vp) return false;
+              for (const k of Object.keys(wanted)) if (vp[k] !== wanted[k]) return false;
+              return true;
+            });
+            if (!match) throw new Error(`No variant in set ${p.componentId} matches properties: ${JSON.stringify(wanted)}`);
+            component = match;
+          } else {
+            component = (set as any).defaultVariant ?? variants[0];
+          }
+        } else if (node.type === "INSTANCE") {
+          throw new Error(`Node ${p.componentId} is an INSTANCE, not a COMPONENT — pass its mainComponentId, or use clone_node if you only need a visual copy`);
+        } else {
+          throw new Error(`Node ${p.componentId} is type ${node.type} — must be COMPONENT or COMPONENT_SET`);
+        }
+      } else {
+        throw new Error("componentId or componentKey is required");
+      }
+
+      const instance = component!.createInstance();
+      if (p.x != null) instance.x = Number(p.x);
+      if (p.y != null) instance.y = Number(p.y);
+      if (p.name) instance.name = p.name;
+      (parent as any).appendChild(instance);
+      figma.commitUndo();
+      return {
+        type: request.type,
+        requestId: request.requestId,
+        data: {
+          id: instance.id,
+          name: instance.name,
+          type: instance.type,
+          bounds: getBounds(instance),
+          mainComponentId: component!.id,
+          mainComponentKey: component!.key,
+        },
+      };
+    }
+
     case "create_section": {
       const p = request.params || {};
       const section = figma.createSection();

--- a/plugin/src/write-create.ts
+++ b/plugin/src/write-create.ts
@@ -73,6 +73,23 @@ export const handleWriteCreateRequest = async (request: any) => {
       textNode.y = p.y != null ? p.y : 0;
       if (p.name) textNode.name = p.name;
       if (p.fillColor) textNode.fills = [makeSolidPaint(p.fillColor)];
+      if (p.textTruncation !== undefined) {
+        if (p.textTruncation !== "DISABLED" && p.textTruncation !== "ENDING") {
+          throw new Error(`textTruncation must be 'DISABLED' or 'ENDING', got: ${p.textTruncation}`);
+        }
+        textNode.textTruncation = p.textTruncation;
+      }
+      if (p.maxLines !== undefined) {
+        if (p.maxLines !== null) {
+          const n = Number(p.maxLines);
+          if (!Number.isFinite(n) || n < 1) {
+            throw new Error("maxLines must be null or a positive integer");
+          }
+          textNode.maxLines = n;
+        } else {
+          textNode.maxLines = null;
+        }
+      }
       (parent as any).appendChild(textNode);
       figma.commitUndo();
       return {

--- a/plugin/src/write-modify.test.ts
+++ b/plugin/src/write-modify.test.ts
@@ -544,3 +544,91 @@ describe("find_replace_text", () => {
     await expect(handleWriteModifyRequest(makeRequest("find_replace_text", [], { find: "x" }))).rejects.toThrow("replace is required");
   });
 });
+
+// ── set_text ──────────────────────────────────────────────────────────────────
+
+describe("set_text", () => {
+  beforeEach(() => {
+    (globalThis as any).figma = {
+      ...(globalThis as any).figma,
+      loadFontAsync: async () => {},
+    };
+  });
+
+  const makeText = (overrides?: any) => ({
+    id: "1:1",
+    name: "Label",
+    type: "TEXT",
+    characters: "old",
+    fontName: { family: "Inter", style: "Regular" },
+    textTruncation: "DISABLED",
+    maxLines: null,
+    ...overrides,
+  });
+
+  it("updates characters when text is provided", async () => {
+    mockNodes["1:1"] = makeText();
+    const res = await handleWriteModifyRequest(makeRequest("set_text", ["1:1"], { text: "new" }));
+    expect(mockNodes["1:1"].characters).toBe("new");
+    expect(res?.data.characters).toBe("new");
+    expect(commitUndoCalled).toBe(true);
+  });
+
+  it("sets textTruncation to ENDING without changing characters", async () => {
+    mockNodes["1:1"] = makeText();
+    const res = await handleWriteModifyRequest(makeRequest("set_text", ["1:1"], { textTruncation: "ENDING" }));
+    expect(mockNodes["1:1"].characters).toBe("old"); // unchanged
+    expect(mockNodes["1:1"].textTruncation).toBe("ENDING");
+    expect(res?.data.textTruncation).toBe("ENDING");
+  });
+
+  it("sets maxLines to a positive integer", async () => {
+    mockNodes["1:1"] = makeText({ textTruncation: "ENDING" });
+    await handleWriteModifyRequest(makeRequest("set_text", ["1:1"], { maxLines: 2 }));
+    expect(mockNodes["1:1"].maxLines).toBe(2);
+  });
+
+  it("clears maxLines when null is passed", async () => {
+    mockNodes["1:1"] = makeText({ maxLines: 5 });
+    await handleWriteModifyRequest(makeRequest("set_text", ["1:1"], { maxLines: null }));
+    expect(mockNodes["1:1"].maxLines).toBeNull();
+  });
+
+  it("rejects invalid textTruncation", async () => {
+    mockNodes["1:1"] = makeText();
+    await expect(
+      handleWriteModifyRequest(makeRequest("set_text", ["1:1"], { textTruncation: "TRUNCATE" })),
+    ).rejects.toThrow("textTruncation must be 'DISABLED' or 'ENDING'");
+  });
+
+  it("rejects non-positive maxLines", async () => {
+    mockNodes["1:1"] = makeText();
+    await expect(
+      handleWriteModifyRequest(makeRequest("set_text", ["1:1"], { maxLines: 0 })),
+    ).rejects.toThrow("maxLines must be null or a positive integer");
+  });
+
+  it("throws if no text/truncation/maxLines provided", async () => {
+    mockNodes["1:1"] = makeText();
+    await expect(
+      handleWriteModifyRequest(makeRequest("set_text", ["1:1"], {})),
+    ).rejects.toThrow("at least one of text, textTruncation, or maxLines is required");
+  });
+
+  it("rejects non-TEXT nodes", async () => {
+    mockNodes["1:1"] = { id: "1:1", type: "FRAME" };
+    await expect(
+      handleWriteModifyRequest(makeRequest("set_text", ["1:1"], { text: "x" })),
+    ).rejects.toThrow("not a TEXT node");
+  });
+
+  it("can update text and truncation in one call", async () => {
+    mockNodes["1:1"] = makeText();
+    await handleWriteModifyRequest(makeRequest("set_text", ["1:1"], {
+      text: "new", textTruncation: "ENDING", maxLines: 3,
+    }));
+    expect(mockNodes["1:1"].characters).toBe("new");
+    expect(mockNodes["1:1"].textTruncation).toBe("ENDING");
+    expect(mockNodes["1:1"].maxLines).toBe(3);
+  });
+});

--- a/plugin/src/write-modify.ts
+++ b/plugin/src/write-modify.ts
@@ -7,19 +7,50 @@ export const handleWriteModifyRequest = async (request: any) => {
       const p = request.params || {};
       const nodeId = request.nodeIds && request.nodeIds[0];
       if (!nodeId) throw new Error("nodeId is required");
-      const node = await figma.getNodeByIdAsync(nodeId);
+      const hasText = typeof p.text === "string";
+      const hasTruncation = p.textTruncation !== undefined;
+      const hasMaxLines = p.maxLines !== undefined;
+      if (!hasText && !hasTruncation && !hasMaxLines) {
+        throw new Error("at least one of text, textTruncation, or maxLines is required");
+      }
+      const node = await figma.getNodeByIdAsync(nodeId) as any;
       if (!node) throw new Error(`Node not found: ${nodeId}`);
       if (node.type !== "TEXT") throw new Error(`Node ${nodeId} is not a TEXT node`);
-      const fontName = typeof node.fontName === "symbol"
-        ? { family: "Inter", style: "Regular" }
-        : node.fontName;
-      await figma.loadFontAsync(fontName);
-      node.characters = p.text;
+      if (hasText) {
+        const fontName = typeof node.fontName === "symbol"
+          ? { family: "Inter", style: "Regular" }
+          : node.fontName;
+        await figma.loadFontAsync(fontName);
+        node.characters = p.text;
+      }
+      if (hasTruncation) {
+        if (p.textTruncation !== "DISABLED" && p.textTruncation !== "ENDING") {
+          throw new Error(`textTruncation must be 'DISABLED' or 'ENDING', got: ${p.textTruncation}`);
+        }
+        node.textTruncation = p.textTruncation;
+      }
+      if (hasMaxLines) {
+        if (p.maxLines !== null) {
+          const n = Number(p.maxLines);
+          if (!Number.isFinite(n) || n < 1) {
+            throw new Error("maxLines must be null or a positive integer");
+          }
+          node.maxLines = n;
+        } else {
+          node.maxLines = null;
+        }
+      }
       figma.commitUndo();
       return {
         type: request.type,
         requestId: request.requestId,
-        data: { id: node.id, name: node.name, characters: node.characters },
+        data: {
+          id: node.id,
+          name: node.name,
+          characters: node.characters,
+          textTruncation: node.textTruncation,
+          maxLines: node.maxLines,
+        },
       };
     }
 

--- a/plugin/src/write-styles.ts
+++ b/plugin/src/write-styles.ts
@@ -46,6 +46,23 @@ export const handleWriteStyleRequest = async (request: any) => {
       if (p.letterSpacingValue != null) {
         style.letterSpacing = { value: Number(p.letterSpacingValue), unit: p.letterSpacingUnit || "PIXELS" };
       }
+      if (p.textTruncation !== undefined) {
+        if (p.textTruncation !== "DISABLED" && p.textTruncation !== "ENDING") {
+          throw new Error(`textTruncation must be 'DISABLED' or 'ENDING', got: ${p.textTruncation}`);
+        }
+        (style as any).textTruncation = p.textTruncation;
+      }
+      if (p.maxLines !== undefined) {
+        if (p.maxLines !== null) {
+          const n = Number(p.maxLines);
+          if (!Number.isFinite(n) || n < 1) {
+            throw new Error("maxLines must be null or a positive integer");
+          }
+          (style as any).maxLines = n;
+        } else {
+          (style as any).maxLines = null;
+        }
+      }
       figma.commitUndo();
       return {
         type: request.type,


### PR DESCRIPTION
Fixes #23.

  ## Summary

  Three features that closed gaps where the MCP server was either silently dropping read data or had no write path at all:

  - **Read effects on nodes** (`2d8b72e`). `serializeStyles` was emitting fills, strokes, corner radius, and padding — but never `effects`. `get_node` / `get_nodes_info` / `get_design_context` / `get_document`
   now report drop shadows, inner shadows, and blurs (and resolve `effectStyleId` to a name when applied). `deduplicateStyles` was extended to dedupe repeated effect arrays into `globalVars.styles` like
  fills/strokes already did.
  - **Read & write `textTruncation` and `maxLines`** (`98b59cf`). Both fields were dropped on read and unreachable on write. Now: `serializeText`, `scan_text_nodes`, and `get_styles` text entries surface them;
   `set_text` accepts any subset of `{text, textTruncation, maxLines}` (text is no longer required); `create_text` and `create_text_style` accept the same two optional fields. `ValidateRPC` enforces the
  constraints at the leader.
  - **`create_instance` tool** (`fe6996b`). `clone_node` only made unlinked copies, so designs that needed a Button on every page ended up with severed clones and no propagation when the source changed.
  `create_instance` produces a real `INSTANCE` linked to its main component. Accepts `componentId` for in-file or `componentKey` to import a published library component from another file. For `COMPONENT_SET`,
  picks a variant via `variantProperties` filter or falls back to the default. Mutually exclusive componentId/componentKey enforced in `ValidateRPC`.

  Tool count: 73 → 74.